### PR TITLE
Adds wkhtmltopdf-heroku in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,10 @@ gem "turbolinks"
 gem "uglifier", ">= 1.3.0"
 gem "webpacker"
 gem "wicked_pdf"
-gem "wkhtmltopdf-binary"
+
+group :production do
+  gem "wkhtmltopdf-heroku", "2.12.5.0"
+end
 
 group :development, :test do
   gem "bullet"
@@ -33,6 +36,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "rspec-rails"
   gem "selenium-webdriver"
+  gem "wkhtmltopdf-binary"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
     wicked_pdf (2.0.2)
       activesupport
     wkhtmltopdf-binary (0.12.5.4)
+    wkhtmltopdf-heroku (2.12.5.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -292,6 +293,7 @@ DEPENDENCIES
   webpacker
   wicked_pdf
   wkhtmltopdf-binary
+  wkhtmltopdf-heroku (= 2.12.5.0)
 
 RUBY VERSION
    ruby 2.7.0p0


### PR DESCRIPTION
- Use wkhtmltopdf-binary in development and test.